### PR TITLE
ゲームフローを継続モナドで表現する

### DIFF
--- a/Cui/Broadcaster.fs
+++ b/Cui/Broadcaster.fs
@@ -19,14 +19,14 @@ module Broadcaster =
       | EvCombat _ ->
           ()
 
-      | EvAttackSelect pl ->
-          ()
-
-      | EvAttack (pl, way) ->
+      | EvAttackSelect (pl, way) ->
           let card = g |> Game.tryDohyoCard pl |> Option.get
           do
             printfn "%s attacked with %A."
               (card.Spec.Name) way
+
+      | EvAttack pl ->
+          ()
 
       | EvDamage (cardId, amount) ->
           let card  = g  |> Game.card cardId

--- a/Cui/Program.fs
+++ b/Cui/Program.fs
@@ -38,9 +38,10 @@ let main argv =
       Broadcaster.broadcaster
     ]
 
-  (pl1, pl2)
-  ||> ZeoFive.Game.play audience
-  |> ignore
+  do
+    (pl1, pl2)
+    ||> ZeoFive.Game.play audience
+    |> printfn "%A"
 
   // exit code
   0

--- a/ZeoFive/Core.fs
+++ b/ZeoFive/Core.fs
@@ -65,7 +65,7 @@ module AttackWay =
     | MagicalAttack  -> PhysicalAttack
 
 module Game =
-  let init ent1 ent2 =
+  let init endGame ent1 ent2 =
     let deckInit plId (ent: Entrant) =
       T5.zip
         (NPCardId.all |> T5.map (fun c -> (plId, c)))
@@ -90,7 +90,7 @@ module Game =
       {
         PlayerStore   = initPlayerStore
         CardStore     = initCardStore
-        Kont          = [EvGameBegin]
+        EndCont       = endGame
         ObsSource     = Observable.Source()
       }
 
@@ -130,12 +130,7 @@ module Game =
     }
 
   let happen ev (g: Game) =
-    { g with
-        Kont = ev :: g.Kont
-      }
-
-  let endWith r g =
-    { g with Kont = [EvGameEnd r] }
+    g.ObsSource.Next(g, ev)
 
   let updatePlayer plId pl (g: Game) =
     { g with

--- a/ZeoFive/Types.fs
+++ b/ZeoFive/Types.fs
@@ -54,8 +54,8 @@ module Types =
     | EvSummonSelect  of PlayerId
     | EvSummon        of CardId
     | EvCombat        of Set<PlayerId>
-    | EvAttackSelect  of PlayerId
-    | EvAttack        of PlayerId * AttackWay
+    | EvAttackSelect  of PlayerId * AttackWay
+    | EvAttack        of PlayerId
     | EvDamage        of CardId * int
     | EvDie           of CardId
     | EvGameBegin
@@ -94,7 +94,7 @@ module Types =
     {
       PlayerStore : Map<PlayerId, Player>
       CardStore   : Map<CardId, Card>
-      Kont        : Event list
+      EndCont     : GameResult -> Cont<GameResult, Game>
       ObsSource   : Observable.Source<Game * Event>
     }
 


### PR DESCRIPTION
## 動機

いままでの実装では、ゲーム終了や戦闘フェイズ終了を扱うために、ゲームの流れをスモールステップで記述していたため、やや不自然だった。

全体を通して継続モナドに包むことで、上述の遷移を自然に記述できる。
## 問題
- [ ] audience を unsubscribe させる方法がない。(unsubscribe させる必要はないので、あくまで潜在的な問題。)
